### PR TITLE
Changed from list of question objects to list of question object ids

### DIFF
--- a/quiz/home/views.py
+++ b/quiz/home/views.py
@@ -48,10 +48,11 @@ def question(request):
         if 'quesset' not in request.session:
             quesset = returnquestionset(category, level, num)
             shuffle(quesset)
-            request.session['quesset'] = quesset
+            request.session['quesset'] = [q.id for q in quesset]
             request.session.save()
         else:
-            quesset = request.session['quesset']
+            quessetIds = request.session['quesset']
+            quesset = [Question.objects.get(pk=pk_id) for pk_id in quessetIds]
         ques=quesset[num]
         answers,correct_answer=returnanswer(ques)
 


### PR DESCRIPTION
**Changed list of question objects to list of question object ids so they are JSON serializable.**

Django stores sessions as JSON files.
The Question objects cannot be converted into JSON but numbers can be.
So, instead of storing a list of Question objects into the session, a list of ids of Question objects are stored into the session.
Then when they are fetched they are converted back to Question objects using Question.objects.get and their primary key (pk)
so they are ready to be used in the already existing code.
Note: By default the id of the object itself is the primary key.